### PR TITLE
Fixes for JupyterHub 2.3

### DIFF
--- a/jupyterhub_oidcp/__init__.py
+++ b/jupyterhub_oidcp/__init__.py
@@ -30,11 +30,15 @@ def _services_to_dict(services: List[dict]) -> List[dict]:
 
 def configure_jupyterhub_oidcp(
     c,
+    issuer: Optional[str] = None,
     base_url: Optional[str] = None,
     internal_base_url: Optional[str] = None,
     port: int = 8888,
     services=[],
     vault_path: Optional[str] = None,
+    email_pattern: Optional[str] = None,
+    admin_email_pattern: Optional[str] = None,
+    user_email_pattern: Optional[str] = None,
     oauth_client_allowed_scopes=["inherit"],
     debug=False
 ):
@@ -50,6 +54,10 @@ def configure_jupyterhub_oidcp(
         "--services", services_def,
         "--port", str(port),
     ]
+    if issuer:
+        service_command.extend([
+            "--issuer", issuer,
+        ])
     if base_url:
         service_command.extend([
             "--base-url", base_url,
@@ -61,6 +69,18 @@ def configure_jupyterhub_oidcp(
     if vault_path:
         service_command.extend([
             "--vault-path", vault_path,
+        ])
+    if email_pattern:
+        service_command.extend([
+            "--email-pattern", email_pattern,
+        ])
+    if admin_email_pattern:
+        service_command.extend([
+            "--admin-email-pattern", admin_email_pattern,
+        ])
+    if user_email_pattern:
+        service_command.extend([
+            "--user-email-pattern", user_email_pattern,
         ])
 
     if debug:

--- a/jupyterhub_oidcp/__init__.py
+++ b/jupyterhub_oidcp/__init__.py
@@ -1,9 +1,9 @@
 import json
 import sys
-from urllib.parse import urljoin
+from typing import Optional, List
 
 
-def _service_to_dict(service: dict) -> dict | None:
+def _service_to_dict(service: dict) -> Optional[dict]:
     """
     Convert a service to a dictionary.
     """
@@ -19,7 +19,8 @@ def _service_to_dict(service: dict) -> dict | None:
         "redirect_uris": service['redirect_uris'],
     }
 
-def _services_to_dict(services: list[dict]) -> list[dict]:
+
+def _services_to_dict(services: List[dict]) -> List[dict]:
     """
     Convert a list of services to a list of dictionaries.
     """
@@ -29,11 +30,11 @@ def _services_to_dict(services: list[dict]) -> list[dict]:
 
 def configure_jupyterhub_oidcp(
     c,
-    base_url: str | None=None,
-    internal_base_url: str | None=None,
-    port: int=8888,
+    base_url: Optional[str] = None,
+    internal_base_url: Optional[str] = None,
+    port: int = 8888,
     services=[],
-    vault_path: str | None=None,
+    vault_path: Optional[str] = None,
     debug=False
 ):
     """

--- a/jupyterhub_oidcp/__init__.py
+++ b/jupyterhub_oidcp/__init__.py
@@ -35,6 +35,7 @@ def configure_jupyterhub_oidcp(
     port: int = 8888,
     services=[],
     vault_path: Optional[str] = None,
+    oauth_client_allowed_scopes=["inherit"],
     debug=False
 ):
     """
@@ -67,12 +68,14 @@ def configure_jupyterhub_oidcp(
             "--debug"
         ])
 
-    c.JupyterHub.services.append({
+    service = {
         "name": service_name,
         "admin": False,
         "url": f"http://localhost:{port}/services/{service_name}",
         "display": False,
         "command": service_command,
         "oauth_no_confirm": True,
-        "oauth_client_allowed_scopes": ["inherit"]
-    })
+    }
+    if oauth_client_allowed_scopes is not None:
+        service["oauth_client_allowed_scopes"] = oauth_client_allowed_scopes
+    c.JupyterHub.services.append(service)

--- a/jupyterhub_oidcp/emailpattern.py
+++ b/jupyterhub_oidcp/emailpattern.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+
+class EmailPattern:
+    """
+    A class to represent an email pattern.
+    """
+
+    def __init__(
+        self,
+        pattern: Optional[str] = None,
+        pattern_admin: Optional[str] = None,
+        pattern_user: Optional[str] = None,
+    ):
+        """
+        Initialize the email pattern.
+
+        :param pattern: The email pattern.
+        :param pattern_admin: The email pattern for an admin user.
+        :param pattern_user: The email pattern for a non-admin user.
+        """
+        self._pattern = pattern
+        self._pattern_admin = pattern_admin
+        self._pattern_user = pattern_user
+        if self._pattern:
+            if self._pattern_admin or self._pattern_user:
+                raise ValueError(
+                    "pattern cannot be set with pattern_admin or pattern_user."
+                )
+            return
+        if not self._pattern_admin or not self._pattern_user:
+            raise ValueError("pattern_admin and pattern_user must be set.")
+
+    def get_pattern_for(self, admin: bool) -> Optional[str]:
+        """
+        Get the email pattern for a user.
+
+        :param admin: Whether the user is an admin.
+        :return: The email pattern.
+        """
+        if self._pattern:
+            return self._pattern
+        if admin:
+            return self._pattern_admin
+        return self._pattern_user

--- a/jupyterhub_oidcp/handlers/__init__.py
+++ b/jupyterhub_oidcp/handlers/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .providerinfo import ProviderInfoHandler, InternalProviderInfoHandler
 from .authorization import AuthorizationHandler
 from .token import TokenHandler

--- a/jupyterhub_oidcp/handlers/authorization.py
+++ b/jupyterhub_oidcp/handlers/authorization.py
@@ -3,6 +3,7 @@ from tornado import web
 
 from .base import BaseOIDHandler
 from ..provider import HubOAuthAuthnMethod
+from ..userstore import UserInfo
 
 
 class AuthorizationHandler(HubOAuthenticated, BaseOIDHandler):
@@ -16,4 +17,6 @@ class AuthorizationHandler(HubOAuthenticated, BaseOIDHandler):
         )
         user = self.get_current_user()
         self.log.debug(f"AuthorizationHandler.get: {resp}, user={user}")
+        userinfo = UserInfo.from_huboauth_user(user)
+        self.userstore.set_user(userinfo)
         self.finish_response(resp)

--- a/jupyterhub_oidcp/handlers/authorization.py
+++ b/jupyterhub_oidcp/handlers/authorization.py
@@ -4,12 +4,15 @@ from tornado import web
 from .base import BaseOIDHandler
 from ..provider import HubOAuthAuthnMethod
 
+
 class AuthorizationHandler(HubOAuthenticated, BaseOIDHandler):
     @web.authenticated
     def get(self):
         resp = self.provider.authorization_endpoint(
             request=self.request.uri,
-            cookie=HubOAuthAuthnMethod.current_user_to_cookie(self.get_current_user())
+            cookie=HubOAuthAuthnMethod.current_user_to_cookie(
+                self.get_current_user()
+            )
         )
         user = self.get_current_user()
         self.log.debug(f"AuthorizationHandler.get: {resp}, user={user}")

--- a/jupyterhub_oidcp/handlers/base.py
+++ b/jupyterhub_oidcp/handlers/base.py
@@ -3,14 +3,17 @@ from oic.utils.http_util import Response
 from tornado import web
 from tornado.log import app_log
 
+from ..userstore import UserStore
+
 
 class BaseOIDHandler(web.RequestHandler):
     @property
     def log(self):
         return self.settings.get('log', app_log)
 
-    def initialize(self, provider: Provider):
+    def initialize(self, provider: Provider, userstore: UserStore):
         self.provider = provider
+        self.userstore = userstore
 
     def finish_response(self, response: Response):
         if response.status_code == 302 or response.status_code == 303:

--- a/jupyterhub_oidcp/handlers/jwks.py
+++ b/jupyterhub_oidcp/handlers/jwks.py
@@ -2,6 +2,7 @@ import json
 
 from .base import BaseOIDHandler
 
+
 class JwksHandler(BaseOIDHandler):
     def get(self):
         keybundle = self.provider.keybundle

--- a/jupyterhub_oidcp/handlers/providerinfo.py
+++ b/jupyterhub_oidcp/handlers/providerinfo.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 from .base import BaseOIDHandler
 
+
 class ProviderInfoHandler(BaseOIDHandler):
     def get(self):
         provider_info = self.provider.providerinfo_endpoint()

--- a/jupyterhub_oidcp/handlers/token.py
+++ b/jupyterhub_oidcp/handlers/token.py
@@ -1,5 +1,6 @@
 from .base import BaseOIDHandler
 
+
 class TokenHandler(BaseOIDHandler):
     def post(self):
         resp = self.provider.token_endpoint(

--- a/jupyterhub_oidcp/handlers/userinfo.py
+++ b/jupyterhub_oidcp/handlers/userinfo.py
@@ -1,5 +1,6 @@
 from .base import BaseOIDHandler
 
+
 class UserInfoHandler(BaseOIDHandler):
     def get(self):
         resp = self.provider.userinfo_endpoint(

--- a/jupyterhub_oidcp/main.py
+++ b/jupyterhub_oidcp/main.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urljoin
 
 from tornado import web
 from jupyterhub.traitlets import URLPrefix
@@ -72,7 +72,7 @@ class OpenIDConnectProviderApp(Application):
     def _base_url_default(self):
         base_url = os.environ['JUPYTERHUB_BASE_URL']
         return base_url
-    
+
     @default("service_prefix")
     def _service_prefix_default(self):
         service_prefix = os.environ['JUPYTERHUB_SERVICE_PREFIX']
@@ -123,7 +123,9 @@ class OpenIDConnectProviderApp(Application):
         logger.info(f"Logging level set to {level}")
 
     def _make_app(self):
-        self.log.info(f"Making OpenID Connect Provider App base_url={self.base_url}, service_prefix={self.service_prefix}")
+        self.log.info("Making OpenID Connect Provider App " +
+                      f"base_url={self.base_url}," +
+                      f"service_prefix={self.service_prefix}")
         services = json.loads(self.services)
         self.log.info(f"Services: {services}")
         provider = HubOAuthProvider(
@@ -153,14 +155,23 @@ class OpenIDConnectProviderApp(Application):
             service_prefix = service_prefix[:-1]
         return web.Application([
             (oauth_callback_url, HubOAuthCallbackHandler),
-            (f'{service_prefix}/.well-known/openid-configuration', ProviderInfoHandler, handler_settings),
+            (
+                f'{service_prefix}/.well-known/openid-configuration',
+                ProviderInfoHandler,
+                handler_settings,
+            ),
             (f'{service_prefix}/internal/.well-known/openid-configuration',
              InternalProviderInfoHandler, handler_settings),
-            (f'{service_prefix}/authorization', AuthorizationHandler, handler_settings),
+            (
+                f'{service_prefix}/authorization',
+                AuthorizationHandler,
+                handler_settings,
+            ),
             (f'{service_prefix}/token', TokenHandler, handler_settings),
             (f'{service_prefix}/userinfo', UserInfoHandler, handler_settings),
             (f'{service_prefix}/jwks.json', JwksHandler, handler_settings),
         ], **tornado_settings)
+
 
 if __name__ == "__main__":
     OpenIDConnectProviderApp.launch_instance()

--- a/jupyterhub_oidcp/userstore/__init__.py
+++ b/jupyterhub_oidcp/userstore/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+from .base import UserStore, UserInfo, NoUserError
+from .memory import MemoryUserStore

--- a/jupyterhub_oidcp/userstore/base.py
+++ b/jupyterhub_oidcp/userstore/base.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+
+
+class UserInfo:
+    @classmethod
+    def from_huboauth_user(cls, response: dict):
+        if 'kind' not in response or response['kind'] != 'user':
+            raise ValueError(
+                f"Invalid response kind: {response.get('kind', None)}"
+            )
+        if 'name' not in response:
+            raise ValueError("Missing 'name' in response.")
+        return cls(
+            uid=response["name"],
+            admin=response.get("admin", False)
+        )
+
+    def __init__(self, uid: str, admin: bool):
+        self.uid = uid
+        self.admin = admin
+
+
+class NoUserError(Exception):
+    pass
+
+
+class UserStore(ABC):
+    @abstractmethod
+    def set_user(self, user: UserInfo):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_user(self, uid: str) -> UserInfo:
+        raise NotImplementedError

--- a/jupyterhub_oidcp/userstore/memory.py
+++ b/jupyterhub_oidcp/userstore/memory.py
@@ -1,0 +1,20 @@
+from .base import UserStore, UserInfo, NoUserError
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryUserStore(UserStore):
+    def __init__(self):
+        self.users = {}
+
+    def set_user(self, user: UserInfo):
+        logger.debug(f"MemoryUserStore.set_user: {user}")
+        self.users[user.uid] = user
+
+    def get_user(self, uid: str) -> UserInfo:
+        if uid not in self.users:
+            raise NoUserError(f"User {uid} not found.")
+        return self.users[uid]


### PR DESCRIPTION
In order to allow this service to be incorporated into OperationHub, the changes below have been implemented.

- It now works with Python 3.8.
- Enabled to specify oauth_client_allowed_scopes as an option to support JupyterHub 2.3.
- Fixed OpenID Connect Provider support for working with etherpad and oauth2-proxy.