### PR TITLE
Remove unnecessary properties from JWKs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: |
+          python3 -m unittest discover jupyterhub_oidcp/tests

--- a/jupyterhub_oidcp/handlers/jwks.py
+++ b/jupyterhub_oidcp/handlers/jwks.py
@@ -9,9 +9,10 @@ class JwksHandler(BaseOIDHandler):
         resp = json.loads(str(keybundle))
         for key in resp['keys']:
             # Remove the private exponent from the key
-            del key['d']
-            if 'k' in key:
-                del key['k']
+            for prop in ['d', 'p', 'q', 'dp', 'dq', 'qi', 'k']:
+                if prop not in key:
+                    continue
+                del key[prop]
         self.log.debug(f"JwksHandler.get: {resp}")
         self.set_status(200)
         self.finish(resp)

--- a/jupyterhub_oidcp/tests/handlers/test_jwks.py
+++ b/jupyterhub_oidcp/tests/handlers/test_jwks.py
@@ -1,0 +1,66 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tornado.web import Application
+from tornado.testing import AsyncHTTPTestCase
+
+from jupyterhub_oidcp.handlers.jwks import JwksHandler
+
+
+class TestJwksHandler(AsyncHTTPTestCase):
+    def get_app(self):
+        # Mock provider and keybundle
+        self.mock_provider = MagicMock()
+        self.mock_keybundle = MagicMock()
+
+        # Sample JWKS data including private key parameters
+        self.mock_keybundle.__str__.return_value = json.dumps({
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "kid": "test-key",
+                    "n": "base64modulus",
+                    "e": "AQAB",
+                    "d": "private-d",
+                    "p": "private-p",
+                    "q": "private-q",
+                    "dp": "private-dp",
+                    "dq": "private-dq",
+                    "qi": "private-qi",
+                    "k": "private-k"
+                }
+            ]
+        })
+        self.mock_provider.keybundle = self.mock_keybundle
+
+        return Application([(
+            r"/jwks",
+            JwksHandler,
+            dict(
+                provider=self.mock_provider,
+                userstore=MagicMock(),
+            ),
+        )])
+
+    def test_get_jwks(self):
+        response = self.fetch("/jwks", method="GET")
+        self.assertEqual(response.code, 200)
+
+        jwks_data = json.loads(response.body)
+        self.assertIn("keys", jwks_data)
+        self.assertEqual(len(jwks_data["keys"]), 1)
+
+        key = jwks_data["keys"][0]
+        self.assertNotIn("d", key)
+        self.assertNotIn("p", key)
+        self.assertNotIn("q", key)
+        self.assertNotIn("dp", key)
+        self.assertNotIn("dq", key)
+        self.assertNotIn("qi", key)
+        self.assertNotIn("k", key)
+
+        self.assertEqual(key["kty"], "RSA")
+        self.assertEqual(key["kid"], "test-key")
+        self.assertEqual(key["n"], "base64modulus")
+        self.assertEqual(key["e"], "AQAB")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,10 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 exclude = ["tmp", "testing"]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-mock",
+]


### PR DESCRIPTION
When using OpenID Connect to link with Jenkins, there were cases where linking was not possible due to the error `Incomplete second private (CRT) representation: The first factor CRT exponent must not be null` https://github.com/felx/nimbus-jose-jwt/blob/master/src/main/java/com/nimbusds/jose/jwk/RSAKey.java#L1387. This was due to some of the CRT for the private key being left in the jwks.json file. Therefore, I made a fix to remove unnecessary properties from the JWKs.