### PR TITLE
Add service_name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ jupyterhub
 The `configure_jupyterhub_oidcp` function accepts the following parameters:
 
 - `c`: JupyterHub configuration object
+- `service_name`: The name of the service, default is `oidcp`
 - `base_url`: The base URL of the JupyterHub
 - `internal_base_url`: The internal base URL of the JupyterHub
 - `debug`: Enable debug mode

--- a/jupyterhub_oidcp/__init__.py
+++ b/jupyterhub_oidcp/__init__.py
@@ -40,12 +40,12 @@ def configure_jupyterhub_oidcp(
     admin_email_pattern: Optional[str] = None,
     user_email_pattern: Optional[str] = None,
     oauth_client_allowed_scopes=["inherit"],
+    service_name="oidcp",
     debug=False
 ):
     """
     Add the OIDC service to the JupyterHub configuration.
     """
-    service_name = "oidcp"
     services_def = json.dumps(_services_to_dict(services))
 
     service_command = [
@@ -90,7 +90,6 @@ def configure_jupyterhub_oidcp(
 
     service = {
         "name": service_name,
-        "admin": False,
         "url": f"http://localhost:{port}/services/{service_name}",
         "display": False,
         "command": service_command,

--- a/jupyterhub_oidcp/tests/test_init.py
+++ b/jupyterhub_oidcp/tests/test_init.py
@@ -1,0 +1,91 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+from jupyterhub_oidcp import configure_jupyterhub_oidcp
+
+class TestConfigureJupyterhubOidcp(unittest.TestCase):
+    def test_basic(self):
+        c = MagicMock()
+        configure_jupyterhub_oidcp(
+            c,
+            base_url="http://localhost:8000",
+            internal_base_url="http://hub:8000",
+            port=8089,
+            debug=True,
+            services=[
+                {
+                    "oauth_client_id": "TEST_CLIENT_ID",
+                    "api_token": "TEST_CLIENT_SECRET",
+                    "redirect_uris": ["http://localhost:9001/ep_openid_connect/callback"],
+                }
+            ],
+            vault_path="./tmp/jupyterhub_oid/.vault",
+        )
+        c.JupyterHub.services.append.assert_called_once_with({
+            'name': 'oidcp',
+            'url': 'http://localhost:8089/services/oidcp',
+            'display': False,
+            'command': [
+                sys.executable,
+                '-m',
+                'jupyterhub_oidcp.main',
+                '--services',
+                '[{"oauth_client_id": "TEST_CLIENT_ID", "api_token": "TEST_CLIENT_SECRET", '
+                + '"redirect_uris": ["http://localhost:9001/ep_openid_connect/callback"]}]',
+                '--port',
+                '8089',
+                '--base-url',
+                'http://localhost:8000',
+                '--internal-base-url',
+                'http://hub:8000',
+                '--vault-path',
+                './tmp/jupyterhub_oid/.vault',
+                '--debug',
+            ],
+            'oauth_no_confirm': True,
+            'oauth_client_allowed_scopes': ['inherit'],
+        })
+
+    def test_service_name(self):
+        c = MagicMock()
+        configure_jupyterhub_oidcp(
+            c,
+            service_name="oidcp_test",
+            base_url="http://localhost:8000",
+            internal_base_url="http://hub:8000",
+            port=8089,
+            debug=True,
+            services=[
+                {
+                    "oauth_client_id": "TEST_CLIENT_ID",
+                    "api_token": "TEST_CLIENT_SECRET",
+                    "redirect_uris": ["http://localhost:9001/ep_openid_connect/callback"],
+                }
+            ],
+            vault_path="./tmp/jupyterhub_oid/.vault",
+        )
+        c.JupyterHub.services.append.assert_called_once_with({
+            'name': 'oidcp_test',
+            'url': 'http://localhost:8089/services/oidcp_test',
+            'display': False,
+            'command': [
+                sys.executable,
+                '-m',
+                'jupyterhub_oidcp.main',
+                '--services',
+                '[{"oauth_client_id": "TEST_CLIENT_ID", "api_token": "TEST_CLIENT_SECRET", '
+                + '"redirect_uris": ["http://localhost:9001/ep_openid_connect/callback"]}]',
+                '--port',
+                '8089',
+                '--base-url',
+                'http://localhost:8000',
+                '--internal-base-url',
+                'http://hub:8000',
+                '--vault-path',
+                './tmp/jupyterhub_oid/.vault',
+                '--debug',
+            ],
+            'oauth_no_confirm': True,
+            'oauth_client_allowed_scopes': ['inherit'],
+        })


### PR DESCRIPTION
To enable OpenID connect endpoints for specific services, the service_name option has been added.
